### PR TITLE
Use cargo nextest to speed up the testing workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin
@@ -40,3 +40,4 @@ jobs:
       run: |
         cargo build --workspace --all-features
         cargo nextest run --workspace --all-features
+        

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,6 @@
 name: Rust CI
 
-on:
-  push:
-    branches:
-      - ci-use-cargo-nextest-to-speed-up-the-testing-workflow
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,7 +14,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name : Cache dependencies
+    - name: Cache dependencies
       uses: actions/cache@v3
       with:
         path: |
@@ -29,9 +23,9 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           ${{ runner.os }}-cargo
 
     - name: Set up Rust
@@ -41,9 +35,6 @@ jobs:
 
     - name: Install Nextest test runner
       uses: taiki-e/install-action@nextest
-
-    - name: Install system dependencies
-      run: sudo apt update && sudo apt install -y libssl-dev pkg-config
 
     - name: Build and Run Test
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,9 @@ jobs:
 
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+        rustflags:
 
     - name: Install Nextest test runner
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,7 @@ jobs:
           ${{ runner.os }}-cargo
 
     - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Install Nextest test runner
       uses: taiki-e/install-action@nextest
@@ -40,4 +38,3 @@ jobs:
       run: |
         cargo build --workspace --all-features
         cargo nextest run --workspace --all-features
-        

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,13 @@ jobs:
       with:
         toolchain: stable
 
+    - name: Install Nextest test runner
+      uses: taiki-e/install-action@nextest
+
     - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+      run: sudo apt update && sudo apt install -y libssl-dev pkg-config
 
     - name: Build and Run Test
       run: |
         cargo build --workspace --all-features
-        cargo test --workspace --all-features
+        cargo nextest run --workspace --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,13 @@ name: Rust CI
 on:
   push:
     branches:
-      - main
+      - ci-use-cargo-nextest-to-speed-up-the-testing-workflow
   pull_request:
     branches:
       - main
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:
@@ -16,6 +19,20 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name : Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          ${{ runner.os }}-cargo
 
     - name: Set up Rust
       uses: actions-rs/toolchain@v1

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Cargo.lock
 
 # Mac OS X Finder metadata
 .DS_Store
+
+# Jetbrains RustRover config folder
+.idea


### PR DESCRIPTION
This pull request adjusted the CI pipeline to incorporate `cargo nextest run` instead of `cargo test` for running tests. This change is meant to significantly improve the speed of the testing process.