### PR TITLE
166 integrate support for peer did method in the mediator

### DIFF
--- a/crates/did-utils/src/methods/peer/errors.rs
+++ b/crates/did-utils/src/methods/peer/errors.rs
@@ -62,3 +62,11 @@ impl From<DIDPeerMethodError> for DIDResolutionError {
         }
     }
 }
+
+impl std::fmt::Display for DIDPeerMethodError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self) // Customize this to format the error as desired
+    }
+}
+
+impl std::error::Error for DIDPeerMethodError {}

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -337,3 +337,19 @@ async fn test_local_did_resolver_resolves_peer_did_successfully() {
         json_canon::to_string(&expected).unwrap()
     );
 }
+
+async fn test_local_did_resolver_fails_on_malformed_peer_did() {
+    // Malformed Peer DID document
+    let malformed_peer_did_doc = r#"{
+        "id": "did:peer:malformed",
+        "authentication": [
+            {
+                "id": "did:peer:malformed#keys-1",
+                "type": "JsonWebKey2020",
+                "controller": "did:peer:malformed",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "InvalidPublicKey"
+                }
+            }

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -353,3 +353,16 @@ async fn test_local_did_resolver_fails_on_malformed_peer_did() {
                     "x": "InvalidPublicKey"
                 }
             }
+            ]
+    }"#;
+
+    let diddoc: Document = serde_json::from_str(malformed_peer_did_doc).unwrap();
+    let resolver = LocalDIDResolver::new(&diddoc);
+
+    // Resolving the malformed Peer DID
+    let did = "did:peer:malformed";
+    let resolved = resolver.resolve(did).await;
+
+    // Expect DIDNotResolved error due to malformed DID document
+    assert!(matches!(resolved.unwrap_err().kind(), ErrorKind::DIDNotResolved));
+}

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -320,3 +320,20 @@ async fn test_local_did_resolver_resolves_peer_did_successfully() {
         ],
         "service": []
     }"#;
+    // Mock Peer DID resolution by setting up a fake resolver
+    let diddoc: Document = serde_json::from_str(peer_did_doc).unwrap();
+    let resolver = LocalDIDResolver::new(&diddoc);
+
+    // Resolving Peer DID
+    let did = "did:peer:123456789abcdefghi";
+    let resolved = resolver.resolve(did).await.unwrap().unwrap();
+
+    // Expected DID Document
+    let expected: serde_json::Value = serde_json::from_str(peer_did_doc).unwrap();
+    
+    // Check if resolved DID document matches the expected document
+    assert_eq!(
+        json_canon::to_string(&resolved).unwrap(),
+        json_canon::to_string(&expected).unwrap()
+    );
+}

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -290,6 +290,7 @@ mod tests {
     }
 }
 
+#[tokio::test]
 async fn test_local_did_resolver_resolves_peer_did_successfully() {
     // Setup a sample Peer DID document
     let peer_did_doc = r#"{
@@ -338,6 +339,7 @@ async fn test_local_did_resolver_resolves_peer_did_successfully() {
     );
 }
 
+#[tokio::test]
 async fn test_local_did_resolver_fails_on_malformed_peer_did() {
     // Malformed Peer DID document
     let malformed_peer_did_doc = r#"{

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -289,3 +289,34 @@ mod tests {
         assert!(resolved.is_none());
     }
 }
+
+async fn test_local_did_resolver_resolves_peer_did_successfully() {
+    // Setup a sample Peer DID document
+    let peer_did_doc = r#"{
+        "id": "did:peer:123456789abcdefghi",
+        "authentication": [
+            {
+                "id": "did:peer:123456789abcdefghi#keys-1",
+                "type": "JsonWebKey2020",
+                "controller": "did:peer:123456789abcdefghi",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": "Gfp9JkyH0SBz7c3skvRFS32NCMkR5VjkxF3aWjUhRXA"
+                }
+            }
+        ],
+        "keyAgreement": [
+            {
+                "id": "did:peer:123456789abcdefghi#keys-2",
+                "type": "JsonWebKey2020",
+                "controller": "did:peer:123456789abcdefghi",
+                "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "X25519",
+                    "x": "SCMU76FUIUVS7HDgIt6EBQHVuEzUjhnEqa7PA-UyH2w"
+                }
+            }
+        ],
+        "service": []
+    }"#;

--- a/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
+++ b/crates/plugins/mediator-coordination/src/didcomm/bridge.rs
@@ -49,7 +49,8 @@ impl DIDResolver for LocalDIDResolver {
                     }))
                     .expect("Should easily convert between DID document representations."),
                 )),
-                
+                Err(err) => Err(Error::new(ErrorKind::DIDNotResolved, Box::new(err))),
+
             }
         } else if did.starts_with("did:key:") {
             let method = DidKey::new_full(true, PublicKeyFormat::Jwk);


### PR DESCRIPTION
Implementing `did:peer` method into our mediator
This approach will let us support both `did:key` and `did:peer` methods in our Mediator.