### PR TITLE
259 write tests to validate reliability features eg simulated network failures retries e3

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,8 +1,10 @@
 name: CD
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v3
 
       - name: Set up Rust
         uses: actions/setup-rust@v1

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-      - name: Set up Rust
-        uses: actions/setup-rust@v1
-        with:
-          rust-version: stable
+    - name: Set up Rust
+      uses: actions/setup-rust@v1
+      with:
+        rust-version: stable
 
       # Deploy to AWS EC2 Or another instance

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -21,4 +21,7 @@ jobs:
       with:
         rust-version: stable
 
-      # Deploy to AWS EC2 Or another instance
+    - name: Deploy to AWS EC2
+      run: |
+        echo "Deploying application to AWS EC2..."
+        # Add your deployment script here

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,3 +51,10 @@ jobs:
 
     - name: Run Tests
       run: cargo nextest run --workspace --all-features
+
+  reliability-tests:
+    name: Reliability Tests
+    runs-on: ubuntu-latest
+    needs: ci
+
+   

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,4 +66,8 @@ jobs:
       with:
         toolchain: stable
 
-    
+    - name: Install Nextest test runner
+      uses: taiki-e/install-action@nextest
+
+    - name: Run Reliability Tests
+      run: cargo nextest run --workspace --all-features --filter reliability

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,4 +57,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: ci
 
-   
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
+          target/cargo-nextest/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ env:
 jobs:
 
   ci:
-    name: Build and test
+    name: Build and Test
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/reliability-features.md
+++ b/docs/reliability-features.md
@@ -1,0 +1,21 @@
+# Documented Test Cases and Results
+### Implementation Status:
+- **✅:** Fully implemented and passing.
+- **⚪:** In progress or partially implemented.
+- **❌:** Not yet implemented.
+
+| **Test Case**                          | **Description**                                                                 | **Expected Outcome**                              | **Implementation Status** |
+|----------------------------------------|---------------------------------------------------------------------------------|--------------------------------------------------|---------------------------|
+| **Simulated Network Failure**          | Validate retry mechanism under network interruptions.                           | Retries the message and delivers successfully.    | ✅                        |
+| **Retry Logic with Timeout**           | Verify that retries stop after the maximum configured limit.                    | Stops retries after 3 attempts.                  | ✅                        |
+| **Message Acknowledgment Validation**  | Ensure acknowledgment is sent upon successful delivery of a message.            | Acknowledgment is sent correctly.                | ✅                        |
+| **Concurrent Message Processing**      | Test mediator's ability to handle multiple concurrent message processing tasks. | All messages are processed without failures.      | ⚪                        |
+| **Message Delivery Confirmation**      | Confirm that delivery status is tracked correctly.                              | Tracks and confirms delivery of all messages.     | ⚪                        |
+| **Exponential Backoff Strategy**       | Validate exponential backoff timing during retries.                             | Backoff increases exponentially with each retry.  | ❌                        |
+| **Connection Timeout Handling**        | Test mediator behavior when connection timeouts occur.                          | Fails gracefully and retries within set limits.   | ❌                        |
+| **Queue Overflow Handling**            | Validate the handling of message queue overflow scenarios.                      | Ensures no data loss and processes in order.      | ❌                        |
+| **Out-of-Order Message Recovery**      | Test ability to recover and process messages received out of order.             | Processes all messages in correct sequence.       | ⚪                        |
+| **Broken Pipe Recovery**               | Validate recovery mechanism when a broken pipe error occurs.                    | Reestablishes connection and retries seamlessly.  | ⚪                        |
+
+---
+


### PR DESCRIPTION
1. In `CI.yml`:

    . Added a separate `reliability-tests` job to isolate tests for retry logic and acknowledgment.
    . Used the `--filter reliability` flag in the `cargo nextest run` command to run only the reliability-related tests.
    . Cached the `target/cargo-nextest` directory to speed up future runs.

2. In `CD.yml`:

    . Added a trigger (`on.workflow_run`) to ensure deployment only happens after the `CI` workflow completes successfully.
    . Added an `if` condition to proceed with deployment only if the `CI` workflow's conclusion is `success`.