### PR TITLE
feat(mediator-coordination): removed nested bodies

### DIFF
--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
@@ -1,5 +1,5 @@
 use crate::{
-    constants::{KEYLIST_2_0, KEYLIST_UPDATE_RESPONSE_2_0, MEDIATE_DENY_2_0},
+    constants::{KEYLIST_2_0, KEYLIST_UPDATE_RESPONSE_2_0, MEDIATE_DENY_2_0, MEDIATE_GRANT_2_0},
     errors::MediationError,
     handler::midlw::ensure_jwm_type_is_mediation_request,
     model::stateful::coord::{
@@ -145,7 +145,7 @@ pub(crate) async fn process_mediate_request(
         Ok(Some(
             Message::build(
                 format!("urn:uuid:{}", Uuid::new_v4()),
-                MEDIATE_DENY_2_0.to_string(),
+                MEDIATE_GRANT_2_0.to_string(),
                 json!(mediation_grant),
             )
             .to(sender_did.clone())

--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
@@ -456,15 +456,15 @@ mod tests {
             "id_alice_keylist_update_request".to_owned(),
             "https://didcomm.org/coordinate-mediation/2.0/keylist-update".to_owned(),
             json!({
-            "updates": [
-                {
-                    "action": "remove",
-                    "recipient_did": "did:key:alice_identity_pub1@alice_mediator"
-                },
-                {
-                    "action": "add",
-                    "recipient_did": "did:key:alice_identity_pub2@alice_mediator"
-                },
+                "updates": [
+                    {
+                        "action": "remove",
+                        "recipient_did": "did:key:alice_identity_pub1@alice_mediator"
+                    },
+                    {
+                        "action": "add",
+                        "recipient_did": "did:key:alice_identity_pub2@alice_mediator"
+                    },
                 ]
             }),
         )
@@ -491,16 +491,16 @@ mod tests {
         assert_eq!(
             response.body,
             json!({
-            "updated": [
-                {
-                    "recipient_did": "did:key:alice_identity_pub1@alice_mediator",
-                    "action": "remove",
-                    "result": "success"
-                },
-                {
-                    "recipient_did":"did:key:alice_identity_pub2@alice_mediator",
-                    "action": "add",
-                    "result": "success"
+              "updated": [
+                 {
+                        "recipient_did": "did:key:alice_identity_pub1@alice_mediator",
+                        "action": "remove",
+                        "result": "success"
+                    },
+                    {
+                        "recipient_did":"did:key:alice_identity_pub2@alice_mediator",
+                        "action": "add",
+                        "result": "success"
                 },
                 ]
             })

--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/handler/stateful.rs
@@ -491,8 +491,8 @@ mod tests {
         assert_eq!(
             response.body,
             json!({
-              "updated": [
-                 {
+                "updated": [
+                    {
                         "recipient_did": "did:key:alice_identity_pub1@alice_mediator",
                         "action": "remove",
                         "result": "success"
@@ -501,7 +501,7 @@ mod tests {
                         "recipient_did":"did:key:alice_identity_pub2@alice_mediator",
                         "action": "add",
                         "result": "success"
-                },
+                    },
                 ]
             })
         );
@@ -519,26 +519,26 @@ mod tests {
             serde_json::from_str::<Vec<Connection>>(
                 r##"[
                     {
-                    "_id": {
-                        "$oid": "6580701fd2d92bb3cd291b2a"
+                        "_id": {
+                            "$oid": "6580701fd2d92bb3cd291b2a"
                         },
                         "client_did": "did:key:z6MkfyTREjTxQ8hUwSwBPeDHf3uPL3qCjSSuNPwsyMpWUGH7",
                         "mediator_did": "did:web:alice-mediator.com:alice_mediator_pub",
                         "routing_did": "did:key:generated",
                         "keylist": [
                             "did:key:alice_identity_pub2@alice_mediator"
-                            ]
-                        },
-                        {
+                        ]
+                    },
+                    {
                         "_id": {
                             "$oid": "6580701fd2d92bb3cd291b2b"
-                            },
-                            "client_did": "did:key:other",
-                            "mediator_did": "did:web:alice-mediator.com:alice_mediator_pub",
-                            "routing_did": "did:key:generated",
-                            "keylist": []
-                            }
-                            ]"##
+                        },
+                        "client_did": "did:key:other",
+                        "mediator_did": "did:web:alice-mediator.com:alice_mediator_pub",
+                        "routing_did": "did:key:generated",
+                        "keylist": []
+                    }
+                ]"##
             )
             .unwrap()
         );
@@ -554,16 +554,16 @@ mod tests {
             "id_alice_keylist_update_request".to_owned(),
             "https://didcomm.org/coordinate-mediation/2.0/keylist-update".to_owned(),
             json!({
-                            "updates": [
-                                {
-                                    "action": "add",
-                                    "recipient_did": "did:key:alice_identity_pub1@alice_mediator"
-                                },
-                                {
-                                    "action": "remove",
+                "updates": [
+                    {
+                        "action": "add",
+                        "recipient_did": "did:key:alice_identity_pub1@alice_mediator"
+                    },
+                    {
+                        "action": "remove",
                         "recipient_did": "did:key:alice_identity_pub2@alice_mediator"
                     },
-                    ]
+                ]
             }),
         )
         .header("return_route".into(), json!("all"))

--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
@@ -229,21 +229,8 @@ pub struct KeylistQueryPaginate {
 /// Response to key list query, containing retrieved keys.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Keylist {
-    /// Uniquely identifies a keylist query response message.
-    pub id: String,
-
-    /// References the protocol URI of this concept.
-    ///
-    /// Typically `https://didcomm.org/coordinate-mediation/2.0/keylist`
-    #[serde(rename = "type")]
-    pub message_type: String,
-
     /// Message body
     pub body: KeylistBody,
-
-    /// Dynamic properties.
-    #[serde(flatten)]
-    pub additional_properties: Option<HashMap<String, Value>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
@@ -579,20 +566,15 @@ mod tests {
 
     #[test]
     fn can_serialize_keylist_message() {
-        let keylist = Keylist {
-            id: "id_alice_keylist".to_string(),
-            message_type: KEYLIST_2_0.to_string(),
-            body: KeylistBody {
-                keys: vec![KeylistEntry {
-                    recipient_did: String::from("did:key:alice_identity_pub1@alice_mediator"),
-                }],
-                pagination: Some(KeylistPagination {
-                    count: 30,
-                    offset: 30,
-                    remaining: 100,
-                }),
-            },
-            additional_properties: None,
+        let keylist = KeylistBody {
+            keys: vec![KeylistEntry {
+                recipient_did: String::from("did:key:alice_identity_pub1@alice_mediator"),
+            }],
+            pagination: Some(KeylistPagination {
+                count: 30,
+                offset: 30,
+                remaining: 100,
+            }),
         };
 
         let expected = json!({
@@ -621,8 +603,6 @@ mod tests {
     #[test]
     fn can_deserialize_keylist_message() {
         let msg = r#"{
-            "id": "id_alice_keylist",
-            "type": "https://didcomm.org/coordinate-mediation/2.0/keylist",
             "body": {
                 "keys": [
                     {
@@ -637,12 +617,7 @@ mod tests {
             }
         }"#;
 
-        // Assert deserialization
-
         let keylist: Keylist = serde_json::from_str(msg).unwrap();
-
-        assert_eq!(&keylist.id, "id_alice_keylist");
-        assert_eq!(&keylist.message_type, KEYLIST_2_0);
 
         assert_eq!(
             keylist.body,

--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
@@ -226,13 +226,6 @@ pub struct KeylistQueryPaginate {
     pub offset: i32,
 }
 
-/// Response to key list query, containing retrieved keys.
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
-pub struct Keylist {
-    /// Message body
-    pub body: KeylistBody,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
 pub struct KeylistBody {
     /// List of retrieved keys.
@@ -576,7 +569,7 @@ mod tests {
                 remaining: 100,
             }),
         };
-        let keylist = Keylist { body: keylist };
+        let keylist = json!({"body": keylist });
         let expected = json!({
             "body": {
                 "keys": [
@@ -600,6 +593,14 @@ mod tests {
 
     #[test]
     fn can_deserialize_keylist_message() {
+        /// to structure to avoid multiple serde calls in test
+        ///
+        #[derive(Deserialize, Serialize)]
+        pub struct Keylist {
+            /// Message body
+            pub body: KeylistBody,
+        }
+
         let msg = r#"{
             "body": {
                 "keys": [

--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/model/stateful/coord.rs
@@ -576,10 +576,8 @@ mod tests {
                 remaining: 100,
             }),
         };
-
+        let keylist = Keylist { body: keylist };
         let expected = json!({
-            "id": "id_alice_keylist",
-            "type": "https://didcomm.org/coordinate-mediation/2.0/keylist",
             "body": {
                 "keys": [
                     {


### PR DESCRIPTION
From the didcomm spec, plaintext message have a unique format which is to be followed by every protocol in the [didcomm](https://identity.foundation/didcomm-messaging/spec/#message-formats) scope, but currently we have a discontinuity at the level of the body field where we have a double nest of body and extra infomation not specified in the spec (id and type)
![body](https://github.com/user-attachments/assets/307964aa-d000-448f-8988-faaceb3cfd74)

Instead of this
![mc](https://github.com/user-attachments/assets/fe9d059a-fd52-43bf-a8a1-0bd5b4ce1e27)


