### PR TITLE
Fix/issue 332

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@ SERVER_PUBLIC_DOMAIN="https://didcomm-mediator.eudi-adorsys.com"
 SERVER_LOCAL_PORT="8080"
 STORAGE_DIRPATH="./storage"
 MONGO_DBN="DIDComm_DB"
-MONGO_URI="mongodb://mongodb:27017"
+MONGO_URI="mongodb://localhost:27017"
 
 # MONGO_URI="mongodb://root:root@mongodb:27017"

--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-SERVER_PUBLIC_DOMAIN="https://didcomm-mediator.eudi-adorsys.com"
-SERVER_LOCAL_PORT="8080"
-STORAGE_DIRPATH="./storage"
-MONGO_DBN="DIDComm_DB"
-MONGO_URI="mongodb://localhost:27017"
-
-# MONGO_URI="mongodb://root:root@mongodb:27017"

--- a/crates/web-plugins/didcomm-messaging/src/midlw.rs
+++ b/crates/web-plugins/didcomm-messaging/src/midlw.rs
@@ -135,7 +135,6 @@ async fn unpack_payload(
         return Err(response.into_response());
     }
 
-    const ROUTING_PROTOCOL_MSG_TYPE: &str = "https://didcomm.org/routing/2.0/forward";
     if plain_message.type_ != ROUTING_PROTOCOL_MSG_TYPE
         && (plain_message.from.is_none() || !metadata.authenticated || metadata.anonymous_sender)
     {

--- a/crates/web-plugins/didcomm-messaging/src/midlw.rs
+++ b/crates/web-plugins/didcomm-messaging/src/midlw.rs
@@ -133,7 +133,9 @@ async fn unpack_payload(
         return Err(response.into_response());
     }
 
-    if plain_message.from.is_none() || !metadata.authenticated || metadata.anonymous_sender {
+    if plain_message.type_ != "https://didcomm.org/routing/2.0/forward"
+        && (plain_message.from.is_none() || !metadata.authenticated || metadata.anonymous_sender)
+    {
         let response = (StatusCode::BAD_REQUEST, Error::AnonymousPacker.json());
 
         return Err(response.into_response());

--- a/crates/web-plugins/didcomm-messaging/src/midlw.rs
+++ b/crates/web-plugins/didcomm-messaging/src/midlw.rs
@@ -23,6 +23,8 @@ use shared::{
     utils::resolvers::{LocalDIDResolver, LocalSecretsResolver},
 };
 
+const ROUTING_PROTOCOL_MSG_TYPE: &str = "https://didcomm.org/routing/2.0/forward";
+
 /// Middleware to unpack DIDComm messages for unified handler
 pub async fn unpack_didcomm_message(
     State(state): State<Arc<AppState>>,
@@ -133,8 +135,8 @@ async fn unpack_payload(
         return Err(response.into_response());
     }
 
-    const FORWARD_PROTOCOL: &str = "https://didcomm.org/routing/2.0/forward";
-    if plain_message.type_ != FORWARD_PROTOCOL
+    const ROUTING_PROTOCOL_MSG_TYPE: &str = "https://didcomm.org/routing/2.0/forward";
+    if plain_message.type_ != ROUTING_PROTOCOL_MSG_TYPE
         && (plain_message.from.is_none() || !metadata.authenticated || metadata.anonymous_sender)
     {
         let response = (StatusCode::BAD_REQUEST, Error::AnonymousPacker.json());

--- a/crates/web-plugins/didcomm-messaging/src/midlw.rs
+++ b/crates/web-plugins/didcomm-messaging/src/midlw.rs
@@ -133,7 +133,8 @@ async fn unpack_payload(
         return Err(response.into_response());
     }
 
-    if plain_message.type_ != "https://didcomm.org/routing/2.0/forward"
+    const FORWARD_PROTOCOL: &str = "https://didcomm.org/routing/2.0/forward";
+    if plain_message.type_ != FORWARD_PROTOCOL
         && (plain_message.from.is_none() || !metadata.authenticated || metadata.anonymous_sender)
     {
         let response = (StatusCode::BAD_REQUEST, Error::AnonymousPacker.json());


### PR DESCRIPTION
We get this error "message must not be anonencypt" during the forward protocol, because the unpacking middle way expect massages to be authcrpt but some protocols like the forward protocol are anoncrypt, so we need to modify the check below to handle that case