### PR TITLE
fix: resolve secret conflict during Helm installation

### DIFF
--- a/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/client/dic.rs
+++ b/crates/web-plugins/didcomm-messaging/protocols/mediator-coordination/src/client/dic.rs
@@ -410,10 +410,7 @@ mod tests {
 
         let encoded_payload = parts[1];
         let payload = match Base64Url.decode(encoded_payload) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(content) => Some(content),
-                Err(_) => None,
-            },
+            Ok(bytes) => String::from_utf8(bytes).ok(),
             Err(_) => None,
         }?;
 

--- a/crates/web-plugins/didcomm-messaging/shared/src/breaker.rs
+++ b/crates/web-plugins/didcomm-messaging/shared/src/breaker.rs
@@ -21,7 +21,7 @@ use tokio::time::Sleep;
 /// *   **Closed:** The circuit is operating normally, and operations are allowed to proceed.
 /// *   **Open:** Operations are immediately rejected without being executed. This prevents overloading the failing service.
 /// *   **Half-Open:** After a timeout period, the circuit enters a half-open state, allowing a limited number of operations to be executed.
-///       If the probe succeeds, the circuit closes; otherwise, it returns to the open state.
+///     If the probe succeeds, the circuit closes; otherwise, it returns to the open state.
 ///
 /// By default, the circuit breaker is configured with the following:
 ///

--- a/mediator-charts/templates/alertmanager-config.yaml
+++ b/mediator-charts/templates/alertmanager-config.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: alertmanager-mediator-kube-prometheus-alertmanager
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 type: Opaque
 stringData:
   alertmanager.yaml: |

--- a/mediator-charts/templates/alertmanager-config.yaml
+++ b/mediator-charts/templates/alertmanager-config.yaml
@@ -3,10 +3,6 @@ kind: Secret
 metadata:
   name: alertmanager-mediator-kube-prometheus-alertmanager
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
 type: Opaque
 stringData:
   alertmanager.yaml: |

--- a/mediator-charts/templates/mediator-pvc.yaml
+++ b/mediator-charts/templates/mediator-pvc.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-deployment-pvc
+  namespace: {{ .Release.Namespace }}
 spec:
   storageClassName: "high-performance" 
   accessModes:

--- a/mediator-charts/values.yaml
+++ b/mediator-charts/values.yaml
@@ -77,6 +77,7 @@ kube-prometheus:
     enabled: true
     secrets: ["alertmanager-mediator-kube-prometheus-alertmanager", "mediator-eks-secret"]
     configMaps: ["alertmanager-discord-template"]
+    externalConfig: true
 
 grafana:
   enabled: true


### PR DESCRIPTION
I fixed the issue by adding the `externalConfig` property and setting its value to true in `values.yaml`, preventing Alertmanager from creating the secret with default configurations.