### PR TITLE
393 update keystore to use aws secrets manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,10 +335,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-credential-types"
-version = "1.2.2"
+name = "aws-config"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.3.1",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -371,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -387,7 +417,6 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -396,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.63.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a971bfe62ca4a228627a1b74a87a7a142979b20b168d2e2884f4893212ebb715"
+checksum = "8565497721d9f18fa29a68bc5d8225b39e1cc7399d7fc6f1ad803ca934341804"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -410,17 +439,106 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
  "http 0.2.12",
- "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-secretsmanager"
+version = "1.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f78dbba23909cb019804796ab361a1155ff793eb0ed38877132055af5a48aba"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.73.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ac1674cba7872061a29baaf02209fefe499ff034dfd91bd4cc59e4d7741489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6a22f077f5fd3e3c0270d4e1a110346cddf6769e9433eb9e6daceb4ca3b149"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d440e1d368759bd10df0dbdddbfff6473d7cd73e9d9ef2363dc9995ac2d711"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -432,7 +550,6 @@ dependencies = [
  "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "percent-encoding",
  "sha2 0.10.8",
  "time",
@@ -452,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -464,7 +581,6 @@ dependencies = [
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -473,13 +589,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0497ef5d53065b7cd6a35e9c1654bd1fefeae5c52900d91d1b188b0af0f29324"
+checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "h2 0.3.26",
  "h2 0.4.8",
  "http 0.2.12",
  "http 1.3.1",
@@ -501,22 +618,42 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
-name = "aws-smithy-runtime"
-version = "1.8.0"
+name = "aws-smithy-observability"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6328865e36c6fd970094ead6b05efd047d3a80ec5fc3be5e743910da9f2ebf8"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -525,7 +662,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "once_cell",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -534,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.4"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
+checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -551,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -576,10 +712,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-types"
-version = "1.3.6"
+name = "aws-smithy-xml"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -587,6 +732,25 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "aws_secretsmanager_caching"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65916cc572d0e225949274e62420844488bb0706f290ffb3aad27cdce25a76b2"
+dependencies = [
+ "aws-config",
+ "aws-sdk-secretsmanager",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "linked-hash-map",
+ "rustls 0.23.25",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.12",
+ "tokio",
 ]
 
 [[package]]
@@ -1547,6 +1711,7 @@ dependencies = [
 name = "did-endpoint"
 version = "0.1.0"
 dependencies = [
+ "aws-config",
  "axum 0.7.9",
  "cfg-if",
  "chrono",
@@ -1654,6 +1819,7 @@ name = "didcomm-messaging"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "axum 0.7.9",
  "dashmap",
  "database",
@@ -2932,7 +3098,10 @@ name = "keystore"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
  "aws-sdk-kms",
+ "aws-sdk-secretsmanager",
+ "aws_secretsmanager_caching",
  "database",
  "did-utils",
  "eyre",
@@ -2942,6 +3111,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4225,6 +4395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.103.0",
@@ -5245,6 +5416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5735,6 +5912,12 @@ dependencies = [
  "serde",
  "zeroize",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xsalsa20poly1305"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,10 +98,12 @@ curve25519-dalek = "4.1.3"
 ed25519-dalek = "2.1.1"
 tracing-subscriber = "0.3.19"
 tower-http = "0.6.2"
-aws-config = "1.1"
+aws-config = "1.6"
+aws-sdk-kms = "1.76"
+aws-sdk-secretsmanager = "1.68"
+aws_secretsmanager_caching = "1.2"
 axum-prometheus = "0.8.0"
 prometheus-client = "0.23.1"
-aws-sdk-kms = "1.49"
 base64ct = { version = "1.6.0", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -66,16 +66,7 @@ docker run --name mongodb -d mongo
 
 ### Environmental variables
 
-You need to create a **`.env`** file in the root directory of the project and add the following variables:
-
-```sh
-SERVER_PUBLIC_DOMAIN="http://localhost:8080"
-STORAGE_DIRPATH="./storage"
-MONGO_DBN="DIDComm_DB"
-MONGO_URI="mongodb://localhost:27017"
-```
-
-> The values can be changed according to your needs.  
+You need to create a **`.env`** file in the root directory of the project. Take a look at the [example](.env.example) file for more information about the needed variables.
 
 You can now start the mediator server:
 

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "keystore"
-version = "0.1.0" 
-authors = ["adorsys GmbH Co. KG"] 
+version = "0.1.0"
+authors = ["adorsys GmbH Co. KG"]
 license = "Apache-2.0"
 description = "The `keystore` is a core component of the DIDComm Mediator system, designed to facilitate secure, decentralized communication within the Self-Sovereign Identity (SSI) ecosystem."
 repository = "https://github.com/adorsys/didcomm-mediator-rs/tree/main/crates/web-plugins/keystore"
-keywords = ["keystore", "didcomm", "didcomm mediator", "didcomm messaging", "rust mediator"]
+keywords = [
+    "keystore",
+    "didcomm",
+    "didcomm mediator",
+    "didcomm messaging",
+    "rust mediator",
+]
 categories = ["cryptography"]
 edition = "2021"
 
@@ -19,9 +25,13 @@ mongodb.workspace = true
 database.workspace = true
 serde.workspace = true
 eyre.workspace = true
+tracing.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
+aws-config.workspace = true
 aws-sdk-kms.workspace = true
+aws-sdk-secretsmanager.workspace = true
+aws_secretsmanager_caching.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [features]

--- a/crates/keystore/src/error.rs
+++ b/crates/keystore/src/error.rs
@@ -2,6 +2,10 @@ use core::fmt::{Debug, Display};
 use std::error::Error as StdError;
 
 use aws_sdk_kms::operation::{decrypt::DecryptError, encrypt::EncryptError};
+use aws_sdk_secretsmanager::operation::{
+    create_secret::CreateSecretError, delete_secret::DeleteSecretError,
+    describe_secret::DescribeSecretError, get_secret_value::GetSecretValueError,
+};
 use serde_json::error::Category;
 
 /// Kind of error that can occur during key store operations.
@@ -103,6 +107,30 @@ impl From<aws_sdk_kms::error::SdkError<EncryptError>> for Error {
 impl From<aws_sdk_kms::error::SdkError<DecryptError>> for Error {
     fn from(err: aws_sdk_kms::error::SdkError<DecryptError>) -> Self {
         Error::new(ErrorKind::DecryptionFailure, err)
+    }
+}
+
+impl From<aws_sdk_secretsmanager::error::SdkError<DescribeSecretError>> for Error {
+    fn from(err: aws_sdk_secretsmanager::error::SdkError<DescribeSecretError>) -> Self {
+        Error::new(ErrorKind::RepositoryFailure, err)
+    }
+}
+
+impl From<aws_sdk_secretsmanager::error::SdkError<CreateSecretError>> for Error {
+    fn from(err: aws_sdk_secretsmanager::error::SdkError<CreateSecretError>) -> Self {
+        Error::new(ErrorKind::RepositoryFailure, err)
+    }
+}
+
+impl From<aws_sdk_secretsmanager::error::SdkError<GetSecretValueError>> for Error {
+    fn from(err: aws_sdk_secretsmanager::error::SdkError<GetSecretValueError>) -> Self {
+        Error::new(ErrorKind::RepositoryFailure, err)
+    }
+}
+
+impl From<aws_sdk_secretsmanager::error::SdkError<DeleteSecretError>> for Error {
+    fn from(err: aws_sdk_secretsmanager::error::SdkError<DeleteSecretError>) -> Self {
+        Error::new(ErrorKind::RepositoryFailure, err)
     }
 }
 

--- a/crates/keystore/src/repository.rs
+++ b/crates/keystore/src/repository.rs
@@ -1,3 +1,4 @@
+pub(crate) mod aws;
 pub(crate) mod mongodb;
 pub(crate) mod no_repo;
 

--- a/crates/keystore/src/repository/aws.rs
+++ b/crates/keystore/src/repository/aws.rs
@@ -1,0 +1,93 @@
+use std::{num::NonZeroUsize, time::Duration};
+
+use async_trait::async_trait;
+use aws_config::SdkConfig;
+use aws_sdk_secretsmanager::{
+    operation::get_secret_value::GetSecretValueError, Client as SecretsClient,
+    Config as SecretsConfig,
+};
+use aws_secretsmanager_caching::SecretsManagerCachingClient as SecretsCacheClient;
+use eyre::eyre;
+use tracing::warn;
+
+use crate::{Error, ErrorKind};
+
+use super::SecretRepository;
+
+/// Type used for AWS Secrets Manager operations
+pub(crate) struct AwsSecretsManager {
+    client: SecretsClient,
+    cache: SecretsCacheClient,
+}
+
+impl AwsSecretsManager {
+    /// Create a new instance of [AwsSecretsManager] with the given AWS SDK config
+    pub async fn new(config: &SdkConfig) -> Self {
+        let client = SecretsClient::new(config);
+        // Cache size: 100 and a TTL of 5 minutes
+        let cache = SecretsCacheClient::from_builder(
+            SecretsConfig::from(config).to_builder(),
+            NonZeroUsize::new(100).unwrap(),
+            Duration::from_secs(300),
+            true,
+        )
+        .await
+        .unwrap();
+
+        Self { client, cache }
+    }
+}
+
+#[async_trait]
+impl SecretRepository for AwsSecretsManager {
+    async fn store(&self, name: &str, data: &[u8]) -> Result<(), Error> {
+        use aws_sdk_secretsmanager::error::SdkError;
+
+        // Store a secret only if it does not already exist
+        match self.client.describe_secret().secret_id(name).send().await {
+            Ok(_) => {
+                warn!("Secret {name} already exists. Skipping...");
+                Ok(())
+            }
+            Err(SdkError::ServiceError(err)) if err.err().is_resource_not_found_exception() => {
+                let secret = String::from_utf8_lossy(data).to_string();
+                // Secret does not exist, try to create it
+                self.client
+                    .create_secret()
+                    .name(name)
+                    .secret_string(secret)
+                    .send()
+                    .await?;
+                Ok(())
+            }
+            Err(sdk_err) => Err(sdk_err.into()),
+        }
+    }
+
+    async fn find(&self, name: &str) -> Result<Option<Vec<u8>>, Error> {
+        use aws_sdk_secretsmanager::error::SdkError;
+
+        match self.cache.get_secret_value(name, None, None, false).await {
+            Ok(value) => Ok(value.secret_string.map(|s| s.into_bytes())),
+            Err(err) => {
+                // Check for ResourceNotFoundException
+                if let Some(SdkError::ServiceError(service_err)) =
+                    err.downcast_ref::<SdkError<GetSecretValueError>>()
+                {
+                    if service_err.err().is_resource_not_found_exception() {
+                        return Ok(None);
+                    }
+                }
+                Err(Error::msg(ErrorKind::RepositoryFailure, eyre!("{err}")))
+            }
+        }
+    }
+
+    async fn delete(&self, name: &str) -> Result<(), Error> {
+        self.client.delete_secret().secret_id(name).send().await?;
+
+        // Invalidate cache by refreshing the secret
+        let _ = self.cache.get_secret_value(name, None, None, true).await;
+        Ok(())
+    }
+}

--- a/crates/web-plugins/did-endpoint/Cargo.toml
+++ b/crates/web-plugins/did-endpoint/Cargo.toml
@@ -24,6 +24,7 @@ dotenv-flow.workspace = true
 multibase.workspace = true
 tracing.workspace = true
 http-body-util.workspace = true
+aws-config.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 hyper = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/web-plugins/didcomm-messaging/Cargo.toml
+++ b/crates/web-plugins/didcomm-messaging/Cargo.toml
@@ -35,6 +35,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 dashmap.workspace = true
 http-body-util.workspace = true
+aws-config.workspace = true
 tokio = { workspace = true, features = ["full"] }
 hyper = { workspace = true, features = ["full"] }
 axum = { workspace = true, features = ["macros"] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   prometheus: 
     image: prom/prometheus
@@ -73,6 +71,21 @@ services:
     networks:
       - mediator-network
 
+  localstack:
+    container_name: localstack
+    image: localstack/localstack
+    ports:
+      - 4566:4566
+    environment:
+      - SERVICES=secretsmanager
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:4566/"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mediator-network
+
   mediator:
     build:
       context: .
@@ -82,7 +95,8 @@ services:
     env_file:
       - .env  
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     networks:
       - mediator-network
 


### PR DESCRIPTION
I added the support for AWS Secrets Manager service and caching support for the mediator secrets. Currently the sercrets are stored in plaintext in the database.
